### PR TITLE
arm/linux: drop an extra copy of the loaded address

### DIFF
--- a/cpu/arm/linux.fth
+++ b/cpu/arm/linux.fth
@@ -166,7 +166,7 @@ defer place-ramdisk
 
 : init-zimage?   ( -- flag )
    loaded                               ( adr len )
-   dup h# 30 <  if  drop false exit  then   ( adr len )
+   dup h# 30 <  if  2drop false exit  then   ( adr len )
    over h# 24 + l@  h# 016f2818  <>  if  drop false exit  then   ( adr len )
    swap >r                              ( len r: adr )
    r@ h# 28 + l@  r@ +                  ( len start r: adr )


### PR DESCRIPTION
The commit 2d7dad95a1f4 ('arm/linux: ignore the size from the zImage
header') duplicates the length of the loaded area before comparing it to
30, but fails to drop the extra copy on early return. Fix that.