### PR TITLE
XO-1 Device Tree enhancements

### DIFF
--- a/cpu/x86/pc/lxdevel/devices.fth
+++ b/cpu/x86/pc/lxdevel/devices.fth
@@ -285,6 +285,7 @@ fload ${BP}/ofw/termemu/fb16.fth
 end-package
 devalias screen /display
 
+fload ${BP}/dev/geode/gpio.fth		 \ Rudimentary GPIO driver
 \ fload ${BP}/dev/geode/acpi.fth           \ Power management
 
 \ LICENSE_BEGIN

--- a/cpu/x86/pc/lxdevel/fw.bth
+++ b/cpu/x86/pc/lxdevel/fw.bth
@@ -83,7 +83,6 @@ dev /
 alias lmove lmove			\ Needed by CS5536 NAND FLASH driver
 dend
 
-fload ${BP}/dev/geode/gpio.fth		\ Rudimentary GPIO driver
 fload ${BP}/cpu/x86/pc/lxdevel/probemem.fth	\ Memory probing
 
 [ifdef] virtual-mode

--- a/cpu/x86/pc/neptune/devices.fth
+++ b/cpu/x86/pc/neptune/devices.fth
@@ -288,6 +288,7 @@ fload ${BP}/ofw/core/muxdev.fth          \ I/O collection/distribution device
 
 \needs md5init  fload ${BP}/ofw/ppp/md5.fth                \ MD5 hash
 
+fload ${BP}/dev/geode/gpio.fth		 \ Rudimentary GPIO driver
 fload ${BP}/dev/geode/acpi.fth           \ Power management
 \ warning @ warning off
 \ : stand-init-io  stand-init-io  h# fff0.0000 to flash-base  ;

--- a/cpu/x86/pc/neptune/fw.bth
+++ b/cpu/x86/pc/neptune/fw.bth
@@ -88,7 +88,6 @@ dev /
 alias lmove lmove			\ Needed by CS5536 NAND FLASH driver
 dend
 
-fload ${BP}/dev/geode/gpio.fth		\ Rudimentary GPIO driver
 fload ${BP}/cpu/x86/pc/neptune/probemem.fth	\ Memory probing
 
 [ifdef] virtual-mode

--- a/cpu/x86/pc/olpc/biosresume.fth
+++ b/cpu/x86/pc/olpc/biosresume.fth
@@ -100,7 +100,8 @@ h# 4000.0000 constant lid-pme  \ PME mapper 6
    [ifdef] cleanup-lid-wakeup  cleanup-lid-wakeup  [then]
    resume-ps2
    wlan-reset
-   dcon-power-on  d# 10 ms  " dcon-restart" screen-ih $call-method
+   dcon-power-on  d# 10 ms  " dcon-restart" dcon-ih $call-method
+   " set-mode" screen-ih $call-method
 ;
 ' (suspend-devices) to suspend-devices
 ' (resume-devices) to resume-devices

--- a/cpu/x86/pc/olpc/build/.gitignore
+++ b/cpu/x86/pc/olpc/build/.gitignore
@@ -5,3 +5,4 @@ dsdt.stamp
 sourceurl
 memtest
 bios_verify*
+testicons/

--- a/cpu/x86/pc/olpc/config.fth
+++ b/cpu/x86/pc/olpc/config.fth
@@ -43,6 +43,7 @@ create machine-signature ," CL1"
 : bundle-suffix$  ( -- adr len )  " 0"  ;
 
 fload ${BP}/cpu/x86/pc/olpc/addrs.fth
+fload ${BP}/cpu/x86/pc/olpc/gpiopins.fth
 
 \ LICENSE_BEGIN
 \ Copyright (c) 2006 FirmWorks

--- a/cpu/x86/pc/olpc/devices.fth
+++ b/cpu/x86/pc/olpc/devices.fth
@@ -272,6 +272,10 @@ fload ${BP}/dev/olpc/kb3700/ecspi.fth      \ EC chip SPI FLASH access
 fload ${BP}/dev/olpc/kb3700/ecserial.fth   \ Serial access to EC chip
 fload ${BP}/dev/olpc/kb3700/ecio.fth       \ I/O space access to EC chip
 
+dev /embedded-controller
+" olpc,xo1-ec" +compatible
+dend
+
 fload ${BP}/cpu/x86/pc/olpc/boardrev.fth   \ Board revision decoding
 
 : cpu-mhz  ( -- n )

--- a/cpu/x86/pc/olpc/devices.fth
+++ b/cpu/x86/pc/olpc/devices.fth
@@ -4,6 +4,15 @@ purpose: Load device drivers according to configuration definitions
 : gx?  ( -- flag )  h# 4c000017 msr@ drop  4 rshift  2 =  ;
 : lx?  ( -- flag )  h# 4c000017 msr@ drop  4 rshift  3 =  ;
 
+\ This depends on a jumper on the board
+: tft-mode?  ( -- flag )
+   gx?  if
+      h# c000.2001 msr@  drop h# 40 and  0<>
+   else
+      true
+   then
+;
+
 fload ${BP}/dev/geode/msr.fth
 fload ${BP}/cpu/x86/pc/isaio.fth
 

--- a/cpu/x86/pc/olpc/devices.fth
+++ b/cpu/x86/pc/olpc/devices.fth
@@ -256,6 +256,7 @@ fload ${BP}/ofw/core/muxdev.fth          \ I/O collection/distribution device
 
 \needs md5init  fload ${BP}/ofw/ppp/md5.fth                \ MD5 hash
 
+fload ${BP}/dev/geode/gpio.fth           \ Rudimentary GPIO driver
 fload ${BP}/dev/geode/acpi.fth           \ Power management
 
 fload ${BP}/dev/olpc/spiflash/memflash.fth \ Memory-mapped FLASH access

--- a/cpu/x86/pc/olpc/devices.fth
+++ b/cpu/x86/pc/olpc/devices.fth
@@ -342,9 +342,15 @@ fload ${BP}/cpu/x86/pc/olpc/gpioinit.fth
 fload ${BP}/cpu/x86/pc/olpc/chipinit.fth
 [then]
 
-0 0  " 1,1"  " /pci" begin-package
+0 0   " "  " /isa" begin-package
+   " i2c-bus" device-name
+   1 " #address-cells" integer-property
+   0 " #size-cells" integer-property
    fload ${BP}/dev/olpc/dcon/dconsmb.fth         \ SMB access to DCON chip
    fload ${BP}/dev/olpc/dcon/dcon.fth            \ DCON control
+end-package
+
+0 0  " 1,1"  " /pci" begin-package
    fload ${BP}/dev/geode/display/loadpkg.fth     \ Geode display
 
    0 0 encode-bytes

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -599,6 +599,11 @@ true                               ' client-symbols?  set-config-int-default
    then
 ;
 
+: camera-dt-fixup
+   " /camera/port/endpoint" " /image-sensor/port/endpoint"
+      ['] link-endpoints catch  if  2drop 2drop  then
+;
+
 : startup  ( -- )
    standalone?  0=  if  exit  then
 
@@ -625,6 +630,7 @@ true                               ' client-symbols?  set-config-int-default
    " probe-" do-drop-in
 
    probe-pci
+   camera-dt-fixup
    show-child
    install-alarm
    sound

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -208,6 +208,9 @@ dend
 
 : background-rgb  ( -- r g b )  h# ff h# ff h# ff  ;
 
+0 value dcon-ih
+: $call-dcon  ( ... -- ... )   dcon-ih $call-method  ;
+
 fload ${BP}/cpu/x86/pc/olpc/devices.fth
 
 fload ${BP}/cpu/x86/pc/olpc/countdwn.fth	\ Startup countdown
@@ -308,9 +311,6 @@ true value user-mode?
 : .clock  ( -- )
    time&date .date space .time  ."  UTC" cr
 ;
-
-\ The DCON methods are in the screen node on this system
-: $call-dcon  ( ... -- ... )   screen-ih $call-method  ;
 
 fload ${BP}/cpu/x86/pc/olpc/banner.fth
 fload ${BP}/ofw/gui/loadmenu.fth
@@ -418,7 +418,7 @@ fload ${BP}/cpu/x86/pc/olpc/rtcwake.fth
 patch drop ms install-console
 
 : dcon-reset-all  ( -- )
-   " screen"  " dcon-off" ['] execute-device-method  catch  if
+   " dcon"  " dcon-off" ['] execute-device-method  catch  if
       2drop 2drop
    then
 
@@ -511,6 +511,7 @@ true                               ' client-symbols?  set-config-int-default
 : console-start  ( -- )
    video-map cr
 
+   " /dcon" open-dev to dcon-ih
    install-mux-io
    cursor-off
    true to text-on?

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -65,6 +65,9 @@ dev /
 1 encode-int  " #address-cells"  property
 1 encode-int  " #size-cells"     property
 " OLPC" encode-string  " architecture" property
+" OLPC XO-1" model
+" amd,geode-lx" +compatible
+" olpc,xo-1" +compatible
 device-end
 
 \ Memory management services

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -91,7 +91,6 @@ dend
 
 fload ${BP}/cpu/x86/pc/olpc/port80.fth	\ Port 80 debug messages
 
-fload ${BP}/dev/geode/gpio.fth		\ Rudimentary GPIO driver
 fload ${BP}/cpu/x86/pc/olpc/probemem.fth	\ Memory probing
 
 [ifdef] virtual-mode

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -604,6 +604,13 @@ true                               ' client-symbols?  set-config-int-default
       ['] link-endpoints catch  if  2drop 2drop  then
 ;
 
+: display-dt-fixup
+   " /display/ports/port@1/endpoint" " /dcon/ports/port@0/endpoint"
+      ['] link-endpoints catch  if  2drop 2drop  then
+   " /dcon/ports/port@1/endpoint" " /panel/port/endpoint"
+      ['] link-endpoints catch  if  2drop 2drop  then
+;
+
 : startup  ( -- )
    standalone?  0=  if  exit  then
 
@@ -631,6 +638,7 @@ true                               ' client-symbols?  set-config-int-default
 
    probe-pci
    camera-dt-fixup
+   display-dt-fixup
    show-child
    install-alarm
    sound

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -220,6 +220,7 @@ end-support-package
 [then]
 devalias nfs net//obp-tftp:last//nfs
 
+fload ${BP}/ofw/core/fdt.fth
 fload ${BP}/cpu/x86/pc/boot.fth
 fload ${BP}/cpu/x86/pc/linux.fth
 

--- a/cpu/x86/pc/olpc/fw.bth
+++ b/cpu/x86/pc/olpc/fw.bth
@@ -92,6 +92,7 @@ dend
 fload ${BP}/cpu/x86/pc/olpc/port80.fth	\ Port 80 debug messages
 
 fload ${BP}/cpu/x86/pc/olpc/probemem.fth	\ Memory probing
+fload ${BP}/dev/olpc/panel.fth		\ LCD panel
 
 [ifdef] virtual-mode
 fload ${BP}/cpu/x86/loadvmem.fth	\ /mmu node

--- a/cpu/x86/pc/olpc/gpiopins.fth
+++ b/cpu/x86/pc/olpc/gpiopins.fth
@@ -1,0 +1,14 @@
+\ GPIO pin assignments - XO-1
+
+d#  1 constant mic-ac-gpio#
+d#  5 constant dcon-stat0-gpio#
+d#  6 constant dcon-stat1-gpio#
+d#  7 constant dcon-irq-gpio#
+d# 10 constant thrm-alrm-gpio#
+d# 11 constant dcon-load-gpio#
+d# 12 constant dcon-blank-gpio#
+d# 14 constant smb-clk-gpio#
+d# 15 constant smb-data-gpio#
+d# 24 constant workaux-gpio#
+d# 26 constant lid-gpio#
+d# 27 constant ecsci-gpio#

--- a/cpu/x86/pc/olpc/gui.fth
+++ b/cpu/x86/pc/olpc/gui.fth
@@ -359,8 +359,8 @@ h# 32 buffer: icon-name
 : dcon-freeze    ( -- )  " dcon-freeze"   $call-dcon  ;
 : dcon-unfreeze  ( -- )  " dcon-unfreeze" $call-dcon  ;
 : wait-output    ( -- )  " wait-output"   $call-dcon  ;
-: dcon-video-save     ( -- )  " video-save"    $call-dcon  ;
-: dcon-video-restore  ( -- )  " video-restore" $call-dcon  ;
+: dcon-video-save     ( -- )  " video-save"    $call-screen  ;
+: dcon-video-restore  ( -- )  " video-restore" $call-screen  ;
 
 \ === Stuff moved from security.fth ===
 

--- a/dev/geode/display/gp.fth
+++ b/dev/geode/display/gp.fth
@@ -94,13 +94,42 @@ alias depth+ wa+
    ['] fbgeode-delete-lines is delete-lines
 ;
 
+: add-simple-framebuffer ( -- )
+   height width frame-buffer-adr             ( height width fba )
+   " /chosen" find-device
+      new-device
+         " framebuffer" device-name
+         " simple-framebuffer" +compatible
+
+         >physical  encode-int               ( height width adr len )
+         2over * 2 *  encode-int encode+      ( height width adr len adr len)
+         " reg" property
+
+         dup 2 * " stride" integer-property  ( height width )
+         " width" integer-property           ( height )
+         " height" integer-property          ( )
+         " r5g6b5" " format" string-property
+         " /display" encode-phandle " display" property
+      finish-device
+   device-end
+;
+
+: remove-simple-framebuffer ( -- )
+    " /chosen/framebuffer"  find-package  if  delete-package  then
+;
+
 : display-install  ( -- )
    init-all
    default-font set-font
    width  height                           ( width height )
    over char-width / over char-height /    ( width height rows cols )
    /scanline depth fb-install gp-install   ( )
+   add-simple-framebuffer
    init-hook
+;
+
+: display-remove  ( -- )
+   remove-simple-framebuffer
 ;
 
 : display-selftest  ( -- failed? )  false  ;

--- a/dev/geode/display/gxfb.fth
+++ b/dev/geode/display/gxfb.fth
@@ -521,8 +521,6 @@ headers
    frame-buffer-adr /fb +  to graphmem
 ;
 
-: display-remove  ( -- )  ;
-
 " display"                      device-type
 " ISO8859-1" encode-string    " character-set" property
 0 0  encode-bytes  " iso6429-1983-colors"  property

--- a/dev/geode/display/gxfb.fth
+++ b/dev/geode/display/gxfb.fth
@@ -474,6 +474,12 @@ d# 12,000  constant scanline-spins
    set-mode
 ;
 
+d# 440 8 /  constant dcon-flag
+
+: maybe-set-cmos  ( -- )
+   tft-mode?  1 and  dcon-flag cmos!
+;
+
 : probe-dcon  ( -- )
    true to dcon?  set-mode
    dcon-gpio-init   \ GPIO stuff

--- a/dev/geode/display/gxfb.fth
+++ b/dev/geode/display/gxfb.fth
@@ -42,7 +42,6 @@ d# 1024 instance value /scanline	\ Frame buffer line width
 : gp!  ( l reg -- )  gp-base + rl!  ;
 : gp@  ( reg -- l )  gp-base + rl@  ;
 
-
 : iand  ( value mask -- )  invert and  ;
 
 : map-frame-buffer  ( -- )
@@ -118,6 +117,20 @@ create timing-dcon
    h# 038f.0383 , h# 038f.0383 , h# 038b.0388 , ( h# 038a.0387 , )  \ vtiming 1,2,3,fp 
 
 true value dcon?
+[ifdef] $call-dcon
+: bright!        " bright!"       $call-dcon    ;
+: backlight-off  " backlight-off" $call-dcon    ;
+: backlight-on   " backlight-on"  $call-dcon    ;
+: set-source     " set-source"    $call-dcon    ;
+: probe-dcon     " probe-dcon"    $call-dcon    ;
+[else]
+false constant atest?
+: bright!        ( level -- )        drop       ;
+: backlight-off  ( -- )                         ;
+: backlight-on   ( -- )                         ;
+: set-source     ( source -- )       drop       ;
+: probe-dcon     ( dc-addr -- flag ) drop false ;
+[then]
 
 : timing  ( -- adr )
    dcon? tft-mode? and  if  timing-dcon  else  timing-1024x768  then
@@ -170,13 +183,6 @@ h# 4c00.0015 constant dotpll
    then                             ( dotpll-hi )
    set-dotpll                       ( )
 ;
-
-[ifndef] dcon-gpio-init
-false to dcon?
-false constant atest?
-\ : tft-mode?  ( -- flag )  h# c000.2001 msr@  drop h# 40 and  0<>  ;
-false constant tft-mode?
-[then]
 
 \ This compensates for a PCB miswiring between the GX and the DCON
 : set-gamma  ( -- )
@@ -417,91 +423,12 @@ previous definitions
 
 \ fload ${BP}/dev/mediagx/video/bitblt.fth
 
-[ifdef] dcon-gpio-init
-
-\ This is a horrible hack to get the DCON PLL started.
-\ What is going on is that you have to start the video timing
-\ generator assuming that the DCON is present, i.e. with 1200x900
-\ timing parameters.  Then you try to turn on the DCON, and check
-\ to see if you get a DCON interrupt at the right video scan line.
-\ If not, you try again.  And again.  Eventually you give up.
-
-\ Each iteration of the loop below takes 2.5 us (measured).
-\ A frame is 1/50 sec, or 20 ms.  If we spin for 25 ms, we are
-\ sure to see scanline 905.  So we use a little longer than 25 ms,
-\ just to be safe.
-d# 12,000  constant scanline-spins
-
-: irq@905?  ( -- dcon? )
-   lock[
-   false
-   scanline-spins 0 do
-      h# 6e dc-base + w@ h# 7ff and d# 905 =  if
-         gpio-data@  dconirq and  0<>       ( false dcon? )
-         nip
-         leave
-      then
-   loop
-   ]unlock
-;
-
-: good-dcon?  ( -- flag )
-   atest?  if    \ A-test boards don't need this PLL kick
-      0 ['] dcon@ catch  if  drop  smb-init  false exit  then
-      wbsplit nip  h# dc =    ( flag )
-      exit  
-   then
-
-   dcon2?  if  true exit  then
-
-   \ Scan line enable (100), color swizzling (20),
-   \ blanking (10), pass thru disable (1)
-   h# 131    1 ['] dcon! catch  if  2drop smb-init  false exit  then  \ Mode
-   h#   0    9 ['] dcon! catch  if  2drop smb-init  false exit  then  \ Mode
-   d# 19 0  do
-      h# cc h# 4b ['] dcon! catch  if  2drop smb-init  then  \ PLL
-   loop
-   h# cc h# 4b ['] dcon! catch  if  2drop smb-init  false exit  then  \ PLL
-
-   irq@905?                     ( flag )
-;
-
-: dcon-restart  ( -- )
-   dcon-gpio-init
-   d# 50 0  do
-      good-dcon?  if  dcon-setup  h# 11 mode!  leave  then
-   loop
-   set-mode
-;
-
-d# 440 8 /  constant dcon-flag
-
-: maybe-set-cmos  ( -- )
-   tft-mode?  1 and  dcon-flag cmos!
-;
-
-: probe-dcon  ( -- )
-   true to dcon?  set-mode
-   dcon-gpio-init   \ GPIO stuff
-   d# 50 0  do
-      good-dcon?  if  dcon-enable  maybe-set-cmos  unloop exit  then
-   loop
-   
-   0 dcon-flag cmos!
-   false to dcon?
-;
-[else]
-: probe-dcon  ( -- ) ;
-: smb-init ;
-: smb-off ;
-[then]
-
 : init-controller  ( -- )
-\   " dcon-present?" evaluate to dcon?
    unlock
    video-off
-   
-   probe-dcon
+
+   true to dcon?  set-mode
+   dc-base probe-dcon to dcon?
 
    \ If we have decided that the DCON is not present, we have to
    \ change the mode back to VGA timing and resolution
@@ -577,7 +504,6 @@ headers
 0 instance value graphmem
 
 : init-all  ( -- )		\ Initializes the controller
-   smb-init
    map-io-regs			\ Enable IO registers
    init-controller		\ Setup the video controller
    declare-props		\ Setup properites
@@ -595,9 +521,7 @@ headers
    frame-buffer-adr /fb +  to graphmem
 ;
 
-: display-remove  ( -- )
-   smb-off
-;
+: display-remove  ( -- )  ;
 
 " display"                      device-type
 " ISO8859-1" encode-string    " character-set" property

--- a/dev/geode/display/gxfb.fth
+++ b/dev/geode/display/gxfb.fth
@@ -527,6 +527,35 @@ headers
 " ISO8859-1" encode-string    " character-set" property
 0 0  encode-bytes  " iso6429-1983-colors"  property
 
+new-device
+   " ports" device-name
+   1 " #address-cells" integer-property
+   0 " #size-cells" integer-property
+
+   : decode-unit  ( adr len -- phys )  $number  if  0  then  ;
+   : encode-unit  ( phys -- adr len )  (u.)  ;
+   : open  ( -- true )  true  ;
+   : close  ( -- )  ;
+
+   \ VGA port
+   new-device
+      " port" device-name
+      0 " reg" integer-property
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+
+   \ LCD port
+   new-device
+      " port" device-name
+      1 " reg" integer-property
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+finish-device
+
 \ LICENSE_BEGIN
 \ Copyright (c) 2006 FirmWorks
 \ 

--- a/dev/geode/gpio.fth
+++ b/dev/geode/gpio.fth
@@ -31,6 +31,11 @@ alias >set noop   ( mask -- mask' )
 
 h# 5140000C constant MSR_LBAR_GPIO
 
+dev /isa
+   " " " gpio-controller" property
+   2 " #gpio-cells" integer-property
+device-end
+
 stand-init: gpio
    MSR_LBAR_GPIO rdmsr  ( lo hi )
    h# 0000f001 <>  abort" GPIO not enabled"

--- a/dev/olpc/cafecamera/cafecamera.bth
+++ b/dev/olpc/cafecamera/cafecamera.bth
@@ -16,6 +16,9 @@ fload ${BP}/dev/olpc/ov7670.fth		\ Load last; most likely to be present
 fload ${BP}/dev/olpc/cafecamera/cafecamera.fth
 fload ${BP}/dev/olpc/cameratest.fth
 
+\ Probe the sensor
+open if close then
+
 end0
 
 end-tokenizing

--- a/dev/olpc/cafecamera/platform.fth
+++ b/dev/olpc/cafecamera/platform.fth
@@ -19,6 +19,13 @@ my-address my-space h# 200.0010 + encode-phys encode+
 
 " reg" property
 
+new-device
+   " port" device-name
+   new-device
+      " endpoint" device-name
+   finish-device
+finish-device
+
 : my-w@  ( offset -- w )  my-space +  " config-w@" $call-parent  ;
 : my-w!  ( w offset -- )  my-space +  " config-w!" $call-parent  ;
 
@@ -65,6 +72,32 @@ h# 21 value camera-smb-slave
    2 ms
    smbus-wait
    bc cl@ drop
+;
+
+: set-sensor-properties  ( compatible$ i2c-addr -- )
+   " /camera/i2c-bus" find-package  if
+      drop 3drop exit
+   then
+
+   new-device
+      " i2c-bus" device-name
+
+      new-device
+         " image-sensor" device-name
+         " reg" integer-property        ( compatible$ )
+         " compatible" string-property  ( )
+
+         new-device
+            " port" device-name
+            new-device
+               " endpoint" device-name
+               h# 1 " hsync-active" integer-property
+               h# 1 " vsync-active" integer-property
+            finish-device
+         finish-device
+
+      finish-device
+   finish-device
 ;
 
 \ This must be headerless so evaluate won't find this version

--- a/dev/olpc/dcon/dcon.fth
+++ b/dev/olpc/dcon/dcon.fth
@@ -234,24 +234,6 @@ dconload constant out-gpios
    \ ['] dcon-interrupt 5 request_irq
 ;
 
-d# 440 8 /  constant dcon-flag
-
-: msr@  ( l -- d )  " rdmsr" eval  ;
-: msr!  ( d l -- )  " wrmsr" eval  ;
-
-\ This depends on a jumper on the board
-: tft-mode?  ( -- flag )
-   gx?  if
-      h# c000.2001 msr@  drop h# 40 and  0<>
-   else
-      true
-   then
-;
-
-: maybe-set-cmos  ( -- )
-   tft-mode?  1 and  dcon-flag cmos!
-;
-
 \ LICENSE_BEGIN
 \ Copyright (c) 2006 FirmWorks
 \ 

--- a/dev/olpc/dcon/dcon.fth
+++ b/dev/olpc/dcon/dcon.fth
@@ -234,8 +234,6 @@ dconload constant out-gpios
    \ ['] dcon-interrupt 5 request_irq
 ;
 
-0 value dcon-found?
-
 d# 440 8 /  constant dcon-flag
 
 : msr@  ( l -- d )  " rdmsr" eval  ;

--- a/dev/olpc/dcon/dcon.fth
+++ b/dev/olpc/dcon/dcon.fth
@@ -3,7 +3,54 @@
 new-device
 " dcon" device-name
 " olpc,xo1-dcon" +compatible
+" himax,hx8837" +compatible
 h# 0d " reg" integer-property
+
+" /isa" encode-phandle
+   dcon-stat0-gpio# encode-int encode+
+   0 encode-int encode+
+" /isa" encode-phandle encode+
+   dcon-stat1-gpio# encode-int encode+
+   0 encode-int encode+
+" stat-gpios" property
+
+" /isa" encode-phandle
+   dcon-load-gpio# encode-int encode+
+   0 encode-int encode+
+" load-gpios" property
+
+" /isa" encode-phandle " interrupt-parent" property
+
+dcon-irq-gpio# encode-int
+2 encode-int encode+ \ IRQ_TYPE_EDGE_FALLING
+" interrupts" property
+
+new-device
+   " ports" device-name
+   1 " #address-cells" integer-property
+   0 " #size-cells" integer-property
+
+   : decode-unit  ( adr len -- phys )  $number  if  0  then  ;
+   : encode-unit  ( phys -- adr len )  (u.)  ;
+   : open  ( -- true )  true  ;
+   : close  ( -- )  ;
+
+   new-device
+      " port" device-name
+      0 " reg" integer-property
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+
+   new-device
+      " port" device-name
+      1 " reg" integer-property
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+finish-device
 
 \ DCON internal registers, accessed via I2C
 \ 0 constant DCON_ID

--- a/dev/olpc/dcon/dconsmb.fth
+++ b/dev/olpc/dcon/dconsmb.fth
@@ -26,7 +26,9 @@ h# 70 value smb-clock  \ 8 is the shortest period the controller allows
 \ This little dance seemed to help at one point when we were having
 \ problems getting the SMBus going reliably.  It might not be
 \ necessary now that we have the clock going slower, but I'm not sure.
-: smb-init  ( -- )  smb-on  smb-stop  smb-off  smb-on  ;
+: bus-init  ( -- )  smb-on  smb-stop  smb-off  smb-on  ;
+
+: bus-reset  ( -- )  smb-stop 1 ms  smb-off  1 ms  smb-on  ;
 
 : smb-status  ( -- b )
    1 smb@  ( dup 1 smb! )
@@ -67,7 +69,7 @@ h# 70 value smb-clock  \ 8 is the shortest period the controller allows
    smb-byte-out  \ Send address and R/W
 ;
 
-: dcon@  ( reg# -- w )
+: reg-w@  ( reg# -- w )
    h# 1a  smb-start   smb-byte-out  wait-ready  \ Address and reg#
    h# 1b  smb-start   \ Switch to read
    wait-ready
@@ -76,12 +78,17 @@ h# 70 value smb-clock  \ 8 is the shortest period the controller allows
    wait-ready  0 smb@   bwjoin  ( w )
    smb-stop
 ;
-: dcon!  ( w reg# -- )
+
+: reg-w!  ( w reg# -- )
    h# 1a  smb-start  smb-byte-out            ( w )
    wbsplit swap  smb-byte-out  smb-byte-out  ( )
    wait-ready
    smb-stop
 ;
+
+: open  ( -- flag )  true  ;
+: close  ( -- )  ;
+
 \ LICENSE_BEGIN
 \ Copyright (c) 2006 FirmWorks
 \ 

--- a/dev/olpc/dcon/mmp2dcon.fth
+++ b/dev/olpc/dcon/mmp2dcon.fth
@@ -256,8 +256,6 @@ h# f value default-bright
    default-bright bright!
 ;
 
-0 value dcon-found?
-
 : maybe-set-cmos  ( -- )  ;
 
 [ifdef] old-way

--- a/dev/olpc/dcon/viadcon.fth
+++ b/dev/olpc/dcon/viadcon.fth
@@ -220,8 +220,6 @@ d# 905 value resumeline  \ Configurable; should be set from args
    1 set-source  \ Unfreeze image
 ;
 
-0 value dcon-found?
-
 d# 440 8 /  constant dcon-flag
 
 : maybe-set-cmos  ( -- )  1  dcon-flag cmos!  ;

--- a/dev/olpc/kb3700/ecio.fth
+++ b/dev/olpc/kb3700/ecio.fth
@@ -1,9 +1,25 @@
 \ See license at end of file
 purpose: Driver for "EC" (KB3700) chip
 
-\ EC access primitives
-
 h# 380 constant iobase
+
+dev /isa new-device
+   " embedded-controller" device-name
+   " embedded-controller" device-type
+
+   " pnpPNP,c09" +compatible
+   " ene,kb3700" +compatible
+
+   h# 62 1 1 encode-reg
+      h# 66 1 1 encode-reg encode+
+      h# 61 1 1 encode-reg encode+
+      h# 68 1 1 encode-reg encode+
+      h# 6c 1 1 encode-reg encode+
+      iobase 1 1 encode-reg encode+
+      " reg" property
+finish-device device-end
+
+\ EC access primitives
 
 : ec@  ( index -- b )  wbsplit iobase 1+ pc!  iobase 2+ pc!  iobase 3 + pc@  ;
 : ec!  ( b index -- )  wbsplit iobase 1+ pc!  iobase 2+ pc!  iobase 3 + pc!  ;

--- a/dev/olpc/panel.fth
+++ b/dev/olpc/panel.fth
@@ -1,0 +1,12 @@
+0 0 " " " /" begin-package
+   " panel" device-name
+   " simple-panel" +compatible
+   " innolux,ls075at011" +compatible
+
+   new-device
+      " port" device-name
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+end-package

--- a/ofw/core/ofwcore.fth
+++ b/ofw/core/ofwcore.fth
@@ -4233,6 +4233,21 @@ d# 32 buffer: canon-prop
 ;
 
 \
+\ Device graph helpers
+\
+
+: link-endpoint                                   ( $endpoint1 $endpoint2 -- )
+   find-device                                    ( $endpoint1)
+       encode-phandle " remote-endpoint" property ( )
+   device-end
+;
+
+: link-endpoints               ( $endpoint1 $endpoint2 -- )
+   2over 2over  link-endpoint  ( $endpoint1 $endpoint2 )
+   2swap        link-endpoint  ( )
+;
+
+\
 \ Generic Client Interface Services
 \
 


### PR DESCRIPTION
This branch adds started off as an attempt to add bindings that would work with a HiMax DCON driver that would have a change to leave drivers/staging/. It also adds missing stuff elsewhere, such a proper device graph for the camera.

It also adds a /simple-framebuffer node and FDT so that a fairly minimal kernel entirely oblivious about OFW or hardware specifics would still work reasonably well on an XO-1.

Tested on a XO-1.