### PR TITLE
A handful of XO-1.75 patches

### DIFF
--- a/cpu/arm/olpc/1.75/lcdcfg.fth
+++ b/cpu/arm/olpc/1.75/lcdcfg.fth
@@ -10,11 +10,9 @@ new-device
    d# 64 " granularity" integer-property
 finish-device
 
-new-device
-   " panel" device-name
+fload ${BP}/dev/olpc/panel.fth
+dev /panel
    " mrvl,dumb-panel" +compatible
-   " simple-panel" +compatible
-   " innolux,ls075at011" +compatible
 
    " OLPC DCON panel" model
    : +i  encode-int encode+  ;
@@ -35,16 +33,6 @@ new-device
 \ so the high nibble changed from 4 (MMP2) to 2 (MMP3) for the same
 \ field value 1.
 [ifdef] mmp3  h# 20001102  [else]  h# 40001102  [then]  " clock-divider-regval" integer-property
-
-   new-device
-      " port" device-name
-      new-device
-         " endpoint" device-name
-         \ " /dcon-i2c/dcon@d/ports/port@1/endpoint" encode-phandle " remote-endpoint" property
-      finish-device
-   finish-device
-
-finish-device
 device-end
 
 [ifdef] has-dcon

--- a/cpu/arm/olpc/gpio-i2c.fth
+++ b/cpu/arm/olpc/gpio-i2c.fth
@@ -16,20 +16,6 @@ purpose: Device tree nodes for I2C buses implemented with GPIOs
    2r> property                 ( )
 ;
 
-: make-sensor-node  ( name$ i2c-addr -- )
-   " /camera-i2c" find-device     ( name$ i2c-addr )
-   new-device                     ( name$ i2c-addr )
-      " reg" integer-property     ( name$ )
-      +compatible                 ( )
-      " image-sensor" device-name
-      0 0 encode-bytes
-         cam-pwr-gpio# 0 encode-gpio
-         cam-rst-gpio# 0 encode-gpio
-      " gpios" property
-   finish-device
-   device-end
-;
-
 dev /
    new-device
       " camera-i2c" device-name

--- a/dev/olpc/dcon/dcon.fth
+++ b/dev/olpc/dcon/dcon.fth
@@ -234,8 +234,6 @@ dconload constant out-gpios
    \ ['] dcon-interrupt 5 request_irq
 ;
 
-0 value dcon-found?
-
 d# 440 8 /  constant dcon-flag
 
 : msr@  ( l -- d )  " rdmsr" eval  ;

--- a/dev/olpc/dcon/mmp2dcon.fth
+++ b/dev/olpc/dcon/mmp2dcon.fth
@@ -301,8 +301,6 @@ h# f value default-bright
    default-bright bright!
 ;
 
-0 value dcon-found?
-
 : maybe-set-cmos  ( -- )  ;
 
 [ifdef] old-way

--- a/dev/olpc/dcon/mmp2dcon.fth
+++ b/dev/olpc/dcon/mmp2dcon.fth
@@ -57,7 +57,6 @@ new-device
       0 " reg" integer-property
       new-device
          " endpoint" device-name
-         " /display/port/endpoint" encode-phandle " remote-endpoint" property
       finish-device
    finish-device
 
@@ -66,7 +65,6 @@ new-device
       1 " reg" integer-property
       new-device
          " endpoint" device-name
-         " /panel/port/endpoint" encode-phandle " remote-endpoint" property
       finish-device
    finish-device
 finish-device
@@ -351,13 +349,8 @@ h# f value default-bright
 
 end-package
 
-" /display/port/endpoint" find-device
-   " /dcon/ports/port@0/endpoint" encode-phandle " remote-endpoint" property
-device-end
-
-" /panel/port/endpoint" find-device
-   " /dcon/ports/port@1/endpoint" encode-phandle " remote-endpoint" property
-device-end
+" /display/port/endpoint" " /dcon/ports/port@0/endpoint" link-endpoints
+" /panel/port/endpoint"   " /dcon/ports/port@1/endpoint" link-endpoints
 
 stand-init:
    has-dcon-ram?  0=  if

--- a/dev/olpc/dcon/viadcon.fth
+++ b/dev/olpc/dcon/viadcon.fth
@@ -220,8 +220,6 @@ d# 905 value resumeline  \ Configurable; should be set from args
    1 set-source  \ Unfreeze image
 ;
 
-0 value dcon-found?
-
 d# 440 8 /  constant dcon-flag
 
 : maybe-set-cmos  ( -- )  1  dcon-flag cmos!  ;

--- a/dev/olpc/mmp2camera/loadpkg.fth
+++ b/dev/olpc/mmp2camera/loadpkg.fth
@@ -70,7 +70,6 @@
       " port" device-name
       new-device
          " endpoint" device-name
-         " /image-sensor/port/endpoint" encode-phandle  " remote-endpoint" property
       finish-device
    finish-device
 end-package
@@ -83,6 +82,4 @@ end-package
    " xclk" " clock-names" string-property
 device-end
 
-" /image-sensor/port/endpoint" find-device
-   " /camera/port/endpoint" encode-phandle " remote-endpoint" property
-device-end
+" /image-sensor/port/endpoint" " /camera/port/endpoint" link-endpoints

--- a/dev/olpc/panel.fth
+++ b/dev/olpc/panel.fth
@@ -1,0 +1,12 @@
+0 0 " " " /" begin-package
+   " panel" device-name
+   " simple-panel" +compatible
+   " innolux,ls075at011" +compatible
+
+   new-device
+      " port" device-name
+      new-device
+         " endpoint" device-name
+      finish-device
+   finish-device
+end-package

--- a/ofw/core/ofwcore.fth
+++ b/ofw/core/ofwcore.fth
@@ -4237,6 +4237,21 @@ d# 32 buffer: canon-prop
 ;
 
 \
+\ Device graph helpers
+\
+
+: link-endpoint                                   ( $endpoint1 $endpoint2 -- )
+   find-device                                    ( $endpoint1)
+       encode-phandle " remote-endpoint" property ( )
+   device-end
+;
+
+: link-endpoints               ( $endpoint1 $endpoint2 -- )
+   2over 2over  link-endpoint  ( $endpoint1 $endpoint2 )
+   2swap        link-endpoint  ( )
+;
+
+\
 \ Generic Client Interface Services
 \
 


### PR DESCRIPTION
This branch picks the commits that would affect XO-1.75 from https://github.com/quozl/openfirmware/pull/6 so that the XO-1.75  branch won't diverge too much from the main one.